### PR TITLE
feat: mock server setup for development & testing

### DIFF
--- a/ui5.yaml
+++ b/ui5.yaml
@@ -10,13 +10,8 @@ framework:
   name: OpenUI5
   version: '1.78.0'
   libraries:
-    - name: sap.f
     - name: sap.m
-    - name: sap.tnt
     - name: sap.ui.core
-    - name: sap.ui.layout
-    - name: sap.ui.table
-    - name: sap.uxap
     - name: themelib_sap_fiori_3
 server:
   customMiddleware:

--- a/webapp/controller/Base.controller.js
+++ b/webapp/controller/Base.controller.js
@@ -1,0 +1,7 @@
+sap.ui.define(['sap/ui/core/mvc/Controller'], function (Controller) {
+  'use strict';
+
+  return Controller.extend('ui5boilerplate.controller.BaseController', {
+    onInit: function () {},
+  });
+});

--- a/webapp/controller/Home.controller.js
+++ b/webapp/controller/Home.controller.js
@@ -1,7 +1,7 @@
-sap.ui.define(['sap/ui/core/mvc/Controller'], function (Controller) {
+sap.ui.define(['ui5boilerplate/controller/Base.controller'], function (BaseController) {
   'use strict';
 
-  return Controller.extend('ui5boilerplate.controller.Home', {
+  return BaseController.extend('ui5boilerplate.controller.Home', {
     onInit: function () {},
 
     /**

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,32 +1,32 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>UI5 Boilerplate</title>
-    <link rel="shortcut icon" href="/favicon.ico" />
 
-    <script
-      id="sap-ui-bootstrap"
-      src="/resources/sap-ui-core.js"
-      data-sap-ui-theme="sap_fiori_3"
-      data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
-      data-sap-ui-compatVersion="edge"
-      data-sap-ui-async="true"
-      data-sap-ui-frameOptions="trusted"
-      data-sap-ui-logLevel="Fatal"
-      data-sap-ui-resourceroots='{
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1.0" />
+  <title>UI5 Boilerplate</title>
+  <link rel="shortcut icon"
+        href="/favicon.ico" />
+
+  <script id="sap-ui-bootstrap"
+          src="resources/sap-ui-core.js"
+          data-sap-ui-theme="sap_fiori_3"
+          data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+          data-sap-ui-compatVersion="edge"
+          data-sap-ui-async="true"
+          data-sap-ui-frameOptions="trusted"
+          data-sap-ui-logLevel="Fatal"
+          data-sap-ui-resourceroots='{
             "ui5boilerplate": "./"
-          }'
-    ></script>
-  </head>
+          }'></script>
+</head>
 
-  <body class="sapUiBody">
-    <div
-      data-sap-ui-component
-      data-name="ui5boilerplate"
-      data-id="container"
-      data-settings='{"id" : "ui5boilerplate"}'
-    ></div>
-  </body>
+<body class="sapUiBody">
+  <div data-sap-ui-component
+       data-name="ui5boilerplate"
+       data-id="container"
+       data-settings='{"id" : "ui5boilerplate"}'></div>
+</body>
+
 </html>

--- a/webapp/localService/metadata.xml
+++ b/webapp/localService/metadata.xml
@@ -1,0 +1,4 @@
+<!-- Metadata file content here -->
+
+<!-- EntitySet.json file should be maintained inder mockdata folder -->
+<!-- Example: Invoices.json -->

--- a/webapp/localService/mockserver.js
+++ b/webapp/localService/mockserver.js
@@ -1,0 +1,22 @@
+sap.ui.define(['sap/ui/core/util/MockServer'], function (MockServer) {
+  'use strict';
+  return {
+    init: function () {
+      // create
+      var oMockServer = new MockServer({
+        rootUri: '', // rootUri and manifest dataSource uri should be same
+      });
+      var oUriParameters = jQuery.sap.getUriParameters();
+      // configure
+      MockServer.config({
+        autoRespond: true,
+        autoRespondAfter: oUriParameters.get('serverDelay') || 1000,
+      });
+      // simulate
+      var sPath = jQuery.sap.getModulePath('ui5boilerplate.localService');
+      oMockServer.simulate(sPath + '/metadata.xml', sPath + '/mockdata');
+      // start
+      oMockServer.start();
+    },
+  };
+});

--- a/webapp/manifest.json
+++ b/webapp/manifest.json
@@ -7,7 +7,8 @@
     "applicationVersion": {
       "version": "1.0.0"
     },
-    "ach": "ach"
+    "ach": "ach",
+    "dataSources": {}
   },
   "sap.ui": {
     "technology": "UI5",
@@ -52,7 +53,7 @@
     "resources": {
       "css": [
         {
-          "uri": "/css/style.css"
+          "uri": "css/style.css"
         }
       ]
     },

--- a/webapp/test/mockServer.html
+++ b/webapp/test/mockServer.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1.0" />
+  <title>UI5 Boilerplate - MockServer Page</title>
+  <link rel="shortcut icon"
+        href="/favicon.ico" />
+
+  <script id="sap-ui-bootstrap"
+          src="/resources/sap-ui-core.js"
+          data-sap-ui-theme="sap_fiori_3"
+          data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+          data-sap-ui-compatVersion="edge"
+          data-sap-ui-async="true"
+          data-sap-ui-frameOptions="trusted"
+          data-sap-ui-logLevel="Fatal"
+          data-sap-ui-resourceroots='{
+            "ui5boilerplate": "../"
+          }'></script>
+
+  <script>
+    sap.ui.getCore().attachInit(function () {
+      sap.ui.require([
+        "ui5boilerplate/localService/mockserver",
+        "sap/m/Shell",
+        "sap/ui/core/ComponentContainer"
+      ], function (mockserver, Shell, ComponentContainer) {
+        mockserver.init();
+
+        new Shell({
+          appWidthLimited: false,
+          app: new ComponentContainer({
+            height: "100%",
+            name: "ui5boilerplate"
+          })
+        }).placeAt("content");
+      });
+
+    });
+  </script>
+</head>
+
+<body class="sapUiBody"
+      id="content">
+
+</body>
+
+</html>

--- a/webapp/view/Home.view.xml
+++ b/webapp/view/Home.view.xml
@@ -15,7 +15,7 @@
     >
       <Image
         ariaDetails="detailsActiveImage"
-        src="assets/ui5_logo.png"
+        src="/assets/ui5_logo.png"
         class="sapUiMediumMarginTop"
         width="200px"
         decorative="false"
@@ -30,10 +30,10 @@
 
     <footer>
 			<Toolbar>
-				<Image src="assets/github_logo.png" width="30px" press="githubLogoPress" />
+				<Image src="/assets/github_logo.png" width="30px" press="githubLogoPress" />
 				<ToolbarSpacer />
 				<ToolbarSpacer />
-				<Image src="assets/integrtr_logo.png" width="120px" press="integrtrLogoPress" />
+				<Image src="/assets/integrtr_logo.png" width="120px" press="integrtrLogoPress" />
 			</Toolbar>
 		</footer>
 


### PR DESCRIPTION
### Changes in this PR:

- Adjusted resource path to fix issues when hosted as BSP application
- Mock server setup

https://sapui5.hana.ondemand.com/1.36.6/docs/guide/bae9d90d2e9c4206889368f04edab508.html

This setup helps to continue with UI development when back-end is not working.
Helps to work with mock data when back-end is not providing data for testing.

Procedure to setup:

Replace `localService/metadata.xml` with your metadata file.
Replace `localService/mockData/EntitySetName.json` with mock data json files.
Run `/test/mockServer.html` instead of regular `index.html`

### Reference GitHub Issues:

--

### Related Screenshots:

--
